### PR TITLE
TST: Fix lightkurve import, improve test header

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,9 +16,11 @@ except ImportError:
 
 
 PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+PYTEST_HEADER_MODULES['scikit-learn'] = 'sklearn'
+PYTEST_HEADER_MODULES['lightkurve'] = 'lightkurve'
+PYTEST_HEADER_MODULES['lpproj'] = 'lpproj'
 
 # We can add these back to test header if they become a test dependency later.
-PYTEST_HEADER_MODULES.pop('Matplotlib', None)
 PYTEST_HEADER_MODULES.pop('h5py', None)
 PYTEST_HEADER_MODULES.pop('Pandas', None)
 

--- a/tests/test_sweet.py
+++ b/tests/test_sweet.py
@@ -3,7 +3,7 @@ import pytest
 from astropy import units as u
 from astropy.utils.data import download_file
 from lightkurve import LightCurve
-from lightkurve.search import open as lc_read  # Will be read in 2.x
+from lightkurve.search import read as lc_read  # Was open in 1.x
 from numpy.testing import assert_allclose
 
 from exovetter import const as exo_const


### PR DESCRIPTION
Looks like `lightkurve` finally changed their API.

Also add additional dependencies to test header.