### PR TITLE
MNT: Update astropy default branch

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         sudo apt-get install libxml2-utils
         python -m pip install --upgrade pip setuptools
-        python -m pip install git+https://github.com/astropy/astropy.git@master#egg=astropy
+        python -m pip install git+https://github.com/astropy/astropy.git@main#egg=astropy
         python -m pip install git+https://github.com/lightkurve/lightkurve.git@main#egg=lightkurve
         python -m pip install -e .[test,all]
     - name: Test with dev deps


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `astropy` has changed its default branch! You can report issues to @pllim.