### PR TITLE
Fix Folding and Folded Light Curve Plots

### DIFF
--- a/exovetter/utils.py
+++ b/exovetter/utils.py
@@ -523,8 +523,16 @@ def compute_phases(time, period, epoch, offset=0.5):
     Returns
     -------
     phases : float
-        Phases in untils of the period.
+        Phases in units of the period. All phases are positive in value.
 
     """
-    phases = np.fmod(time - epoch + (offset * period), period)
+    # Determine Epoch just less than the smallest time before folding
+    n_periods = np.abs(np.min(time) - epoch) / period
+    if epoch > np.min(time):
+        epoch0 = epoch - np.ceil(n_periods) * period
+    else:
+        epoch0 = epoch + np.floor(n_periods) * period
+    phases = np.fmod(time - epoch0 + (offset * period), period)
+    pmin = np.min(phases)
+
     return phases

--- a/exovetter/vetters.py
+++ b/exovetter/vetters.py
@@ -533,13 +533,13 @@ class VizTransits(BaseVetter):
                                                     duration_days,
                                                     depth, max_transits=self.max_transits,
                                                     transit_only=self.transit_only,
-                                                    plot=plot)
+                                                    plot=plot, units="d")
 
         viz_transits.plot_fold_transit(time, flux, period_days,
                                        epoch, depth, duration_days,
                                        smooth=self.smooth,
                                        transit_only=self.transit_only,
-                                       plot=plot)
+                                       plot=plot, units="d")
 
         return {'num_transits': n_has_data}
 


### PR DESCRIPTION
I fixed the utils folding algorithm to make it robust against epochs that are larger than the minimum time. We don't get negative phases now.
I added hspan to the folded plots to show the location and duration of the "transit" event.