### PR TITLE
MNT: Update codecov-action version to v2

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Test with stable deps and coverage
       run: pytest --cov=./ --cov-report=xml --remote-data
 #    - name: Coverage report
-#      uses: codecov/codecov-action@v1
+#      uses: codecov/codecov-action@v2
 
 #  dev_deps_tests:
 #    runs-on: ubuntu-latest


### PR DESCRIPTION
You are using a deprecated version of `codecov-action`, see https://github.com/codecov/codecov-action for more details. xref astropy/astropy#12245

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.