### PR TITLE
Added rtol on boundedvals test in test_trapz_fit.py

### DIFF
--- a/tests/test_trapz_fit.py
+++ b/tests/test_trapz_fit.py
@@ -65,7 +65,7 @@ class TestDAVE:
                                          0.20759337, 0.03783464], rtol=5e-6)
         assert_allclose(ioblk.bestphysvals, ioblk.physvals)
         assert_allclose(ioblk.boundedvals, [-3.09340749e-03, -1.48800535,
-                                            -5.36273499e-01, -3.23596121])
+                                            -5.36273499e-01, -3.23596121], rtol=5e-6) # Added rtol to have same as physvals
         assert_allclose(ioblk.bestboundedvals, ioblk.boundedvals)
 
         planet = ioblk.planetests


### PR DESCRIPTION
Hopefully this allows the test to pass. Maybe there was a reason it had no r_tol??